### PR TITLE
Address pane title font size

### DIFF
--- a/src/pages/Workspace/tiles_styles.css
+++ b/src/pages/Workspace/tiles_styles.css
@@ -16,6 +16,7 @@
 .react-tile-pane-tab {
   width: 100%;
   height: 100%;
+  font-size: 1rem;
 }
 .react-tile-pane-tabMoving {
   padding: 0.3em 1em;


### PR DESCRIPTION
This PR returns the pane title font size back into scope.

Before this PR:
![image](https://github.com/user-attachments/assets/ceee1da6-f023-4eac-a750-0a170ba1e1a1)

After this PR:
![image](https://github.com/user-attachments/assets/7329fe45-1c67-4970-9aed-884020fee312)