### PR TITLE
Warn on leaving workspace

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -40,6 +40,10 @@
     "choose_resources": {
       "en": "Choose resources to display in your workspace",
       "fr": "Choisissez des ressources qui seront affichées sur votre plan de travail"
+    },
+    "save_your_work": {
+      "en": "Save your work before leaving this page!",
+      "fr": "Enregistrez votre travail avant de quitter cette page !"
     }
   }
 }

--- a/src/munchers/TextTranslation/TextTranslationEditorMuncher.jsx
+++ b/src/munchers/TextTranslation/TextTranslationEditorMuncher.jsx
@@ -19,10 +19,15 @@ function TextTranslationEditorMuncher({metadata, selectedFontClass}) {
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);
     const [usj, setUsj] = useState(null);
+    const [contentChanged, _setContentChanged] = useState(false);
     const [bookCode, setBookCode] = useState(
         (bcvRef.current && bcvRef.current.bookCode) ||
         "TIT"
     )
+    const setContentChanged = nv => {
+        console.log("setContentChanged", nv);
+        _setContentChanged(nv);
+    }
 
     // Fetch new USFM as USJ, put in incoming
     useEffect(
@@ -62,6 +67,7 @@ function TextTranslationEditorMuncher({metadata, selectedFontClass}) {
                 `${doI18n("pages:core-local-workspace:saved", i18nRef.current)}`,
                 {variant: "success"}
             );
+            setContentChanged(false);
             return response.json;
         } else {
             enqueueSnackbar(
@@ -87,7 +93,17 @@ function TextTranslationEditorMuncher({metadata, selectedFontClass}) {
          */
         const recoverableState = editorState.toJSON();
         debugRef && debugRef.current && console.log("onHistoryChange", recoverableState);
+        setContentChanged(true);
     }
+
+    useEffect(() => {
+        const onBeforeUnload = ev => {
+            ev.preventDefault();
+        };
+        window.addEventListener('beforeunload', onBeforeUnload);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
 
     const {referenceHandler} = useAppReferenceHandler();
 


### PR DESCRIPTION
This PR attempts to warn on leaving the workspace.
- I couldn't make this behaviour conditional on the `contentChanged` flag. However I tried it, changes after initializing `useState` had no effect
- You can still go back to the previous "page" which is really the same page.

But I think it's better than nothing.