### PR TITLE
use full width if only created is included (no resources)

### DIFF
--- a/src/pages/ConfigureWorkspace/ConfigureWorkspace.jsx
+++ b/src/pages/ConfigureWorkspace/ConfigureWorkspace.jsx
@@ -86,7 +86,7 @@ function ConfigureWorkspace() {
                   <PlayArrowIcon/>
               </Fab>
             </Box>
-            <Box style={{position: 'fixed', top: '105px', bottom: 0, overflow: 'scroll', marginBottom: "16px",}}>
+            <Box style={{position: 'fixed', top: '105px', bottom: 0, overflow: 'scroll', marginBottom: "16px", width: '100%'}}>
                 <Grid2
                     container
                     spacing={1}


### PR DESCRIPTION
This fixes the scenario in the screenshot below.  This is a _before_-this-PR screenshot.
![image](https://github.com/user-attachments/assets/609e509a-276c-4a18-a6ae-6ad66d393635)

The after expands the grid to full width. Yes, the scrollbar is still there, in this case without a `right: 0` needed.