### PR TITLE
Change to Graphite detection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Pankosmia Editor" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "deep-copy": "^1.4.2",
         "deep-equal": "^2.2.3",
         "eslint-config-react-app": "^7.0.1",
+        "font-detect-rhl": "^1.1.7",
         "lexical": "^0.21.0",
         "lucide-react": "^0.344.0",
         "md5": "^2.3.0",
@@ -10850,6 +10851,22 @@
         }
       }
     },
+    "node_modules/font-detect-rhl": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/font-detect-rhl/-/font-detect-rhl-1.1.7.tgz",
+      "integrity": "sha512-2HbmAPVJCd1u1ddNqJzFUXyYLvHN8ZnmGLL7cduR57mBr1dI9fPwyXZ9x/OLs58H7uP/lmeqqmHyTl2XefKoWQ==",
+      "dependencies": {
+        "prop-types": "^15.6.1",
+        "use-deep-compare": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -17023,9 +17040,9 @@
       }
     },
     "node_modules/pithekos-lib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.10.3.tgz",
-      "integrity": "sha512-ynvW8xFKchjdPOTk/2U1/GOcuBdSQWbhIK0Q46bCIB4mKPiHA0CbbXZvqpgVsBpLw5Fr7VwWVfJYWO6tgBcGFw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.10.7.tgz",
+      "integrity": "sha512-SC7BY2msMpKfiBLPb0wJH3jOkKcDEDIXIzi+Hkss8G+dDpkQ2HTlpUucZnJeNiOdsj/PGQB3cleR76d6VyLKcA==",
       "dependencies": {
         "@babel/cli": "^7.24.8",
         "@babel/core": "^7.24.8",
@@ -21788,6 +21805,17 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-deep-compare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-deep-compare/-/use-deep-compare-1.3.0.tgz",
+      "integrity": "sha512-94iG+dEdEP/Sl3WWde+w9StIunlV8Dgj+vkt5wTwMoFQLaijiEZSXXy8KtcStpmEDtIptRJiNeD4ACTtVvnIKA==",
+      "dependencies": {
+        "dequal": "2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/usfm-js": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deep-copy": "^1.4.2",
     "deep-equal": "^2.2.3",
     "eslint-config-react-app": "^7.0.1",
+    "font-detect-rhl": "^1.1.7",
     "lexical": "^0.21.0",
     "lucide-react": "^0.344.0",
     "md5": "^2.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/munchers/TextTranslation/TextTranslationEditorMuncher.jsx
+++ b/src/munchers/TextTranslation/TextTranslationEditorMuncher.jsx
@@ -14,7 +14,7 @@ import {enqueueSnackbar} from "notistack";
 import Editor from "./Editor";
 import {useAppReferenceHandler} from "./useAppReferenceHandler";
 
-function TextTranslationEditorMuncher({metadata, selectedFontClass}) {
+function TextTranslationEditorMuncher({metadata, adjSelectedFontClass}) {
     const {bcvRef} = useContext(BcvContext);
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);

--- a/src/munchers/TextTranslation/TextTranslationViewerMuncher.jsx
+++ b/src/munchers/TextTranslation/TextTranslationViewerMuncher.jsx
@@ -4,7 +4,7 @@ import {Proskomma} from 'proskomma-core';
 
 import {getText, debugContext, bcvContext} from "pithekos-lib";
 
-function TextTranslationViewerMuncher({metadata, selectedFontClass}) {
+function TextTranslationViewerMuncher({metadata, adjSelectedFontClass}) {
     const {systemBcv} = useContext(bcvContext);
     const {debugRef} = useContext(debugContext);
     const [verseText, setVerseText] = useState([]);
@@ -46,7 +46,7 @@ function TextTranslationViewerMuncher({metadata, selectedFontClass}) {
         }
     }
 
-    return <div className={selectedFontClass}>
+    return <div className={adjSelectedFontClass}>
         {
             verseText.length > 0 ?
                 verseText.map(b => <p style={{marginBottom: "1em"}}>{b.items.map(i => renderItem(i))}</p>) :

--- a/src/munchers/TextTranslation/blockRenderers.jsx
+++ b/src/munchers/TextTranslation/blockRenderers.jsx
@@ -1,7 +1,7 @@
 import {useState} from "react";
 import {InlineRenderer} from "./inlineRenderers";
 
-function ParaRenderer({usj, marker, nPara, selectedPath, setSelectedPath, setUsjNode, selectedFontClass}) {
+function ParaRenderer({usj, marker, nPara, selectedPath, setSelectedPath, setUsjNode, adjSelectedFontClass}) {
     return <p
         style={{
             display: "flex",
@@ -28,7 +28,7 @@ function ParaRenderer({usj, marker, nPara, selectedPath, setSelectedPath, setUsj
                             contentPath={[nPara, n]}
                             usj={usj}
                             setUsjNode={setUsjNode}
-                            selectedFontClass={selectedFontClass}
+                            adjSelectedFontClass={adjSelectedFontClass}
                         />
                 )
             )
@@ -37,7 +37,7 @@ function ParaRenderer({usj, marker, nPara, selectedPath, setSelectedPath, setUsj
 }
 
 
-function ChapterRenderer({usj, nPara, selectedPath, setSelectedPath, setUsjNode, selectedFontClass}) {
+function ChapterRenderer({usj, nPara, selectedPath, setSelectedPath, setUsjNode, adjSelectedFontClass}) {
     const chapterNumber = `${usj.content[nPara]["number"]}`;
     const [editedValue, setEditedValue] = useState(chapterNumber);
     return <p
@@ -61,7 +61,7 @@ function ChapterRenderer({usj, nPara, selectedPath, setSelectedPath, setUsjNode,
                     }}
                 >
                     <input
-                        className={`${selectedFontClass} usfm-c`}
+                        className={`${adjSelectedFontClass} usfm-c`}
                         style={{
                             padding: 0,
                             width: "100%"

--- a/src/munchers/TextTranslation/inlineRenderers.jsx
+++ b/src/munchers/TextTranslation/inlineRenderers.jsx
@@ -15,7 +15,7 @@ const contentForPath = (content, path) => {
     }
 }
 
-function InlineRenderer({usj, element, contentPath, selectedPath, setSelectedPath, setUsjNode, selectedFontClass}) {
+function InlineRenderer({usj, element, contentPath, selectedPath, setSelectedPath, setUsjNode, adjSelectedFontClass}) {
     if (typeof element === "string") {
         return <StringRenderer
             selectedPath={selectedPath}
@@ -31,7 +31,7 @@ function InlineRenderer({usj, element, contentPath, selectedPath, setSelectedPat
             contentPath={contentPath}
             usj={usj}
             setUsjNode={setUsjNode}
-            selectedFontClass={selectedFontClass}
+            adjSelectedFontClass={adjSelectedFontClass}
         />
     } else if (element.type === "ms") {
         return <MilestoneRenderer
@@ -66,7 +66,7 @@ function InlineRenderer({usj, element, contentPath, selectedPath, setSelectedPat
     </span>;
 }
 
-function VerseRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsjNode, selectedFontClass}) {
+function VerseRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsjNode, adjSelectedFontClass}) {
     const [editedValue, setEditedValue] = useState(contentForPath(usj, contentPath)["number"]);
     return <span
         className="usfm-v"
@@ -76,7 +76,7 @@ function VerseRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsjN
             deepEqual(selectedPath, contentPath) ?
                 <>
                     <input
-                        className={`${selectedFontClass} usfm-v`}
+                        className={`${adjSelectedFontClass} usfm-v`}
                         style={{
                             padding: 0,
                             width: "100%"
@@ -128,12 +128,12 @@ function CharRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsjNo
     </span>;
 }
 
-function StringRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsjNode, selectedFontClass}) {
+function StringRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsjNode, adjSelectedFontClass}) {
     const initialValue = contentForPath(usj, contentPath)
     const [editedValue, setEditedValue] = useState(initialValue);
     const paraUsfmName = `usfm-${usj.content[contentPath[0]].marker}`;
     return <span
-        className={`bare-text ${selectedFontClass} ${paraUsfmName}`}
+        className={`bare-text ${adjSelectedFontClass} ${paraUsfmName}`}
         style={{
             display: "inline-block",
             size: 1
@@ -144,7 +144,7 @@ function StringRenderer({usj, selectedPath, setSelectedPath, contentPath, setUsj
             deepEqual(selectedPath, contentPath) ?
                 <>
                     <input
-                        className={`${selectedFontClass} ${paraUsfmName}`}
+                        className={`${adjSelectedFontClass} ${paraUsfmName}`}
                         style={{
                             padding: 0,
                             width: "100%"

--- a/src/pages/Workspace/GraphiteTest.jsx
+++ b/src/pages/Workspace/GraphiteTest.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import {useDetectRender} from 'font-detect-rhl';
+
+export default function GraphiteTest() {
+
+  const [testFont, setTestFont] = useState('');
+  const [hasRunOnce, setHasRunOnce] = useState(false);
+
+  const font = new FontFace("Pankosmia-GraphiteTest", "url(/webfonts/awami/AwamiNastaliq-Regular.woff2)", {
+    style: "normal",
+    weight: "normal",
+  });
+
+  document.fonts.add(font);
+  
+  async function check() {
+    await font.load();
+    setTestFont('Pankosmia-GraphiteTest');
+  }
+
+  useEffect ( () => {
+    if (!hasRunOnce) {
+      check();
+      setHasRunOnce(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[hasRunOnce])
+
+  const testFontArray = [{ name: testFont }];
+  const renderType = useDetectRender({fonts:testFontArray});
+  const isGraphite = renderType[0].detectedRender === 'RenderingGraphite';
+
+  return isGraphite;
+}

--- a/src/pages/Workspace/Workspace.jsx
+++ b/src/pages/Workspace/Workspace.jsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import {useLocation} from "react-router-dom";
 import WorkspaceCard from "./WorkspaceCard";
 import BcvPicker from "./BcvPicker";
-import {useDetectRender} from 'font-detect-rhl';
+import GraphiteTest from "./GraphiteTest";
 import {
     createTilePanes,
     TileContainer,
@@ -52,11 +52,10 @@ const Workspace = () => {
         rootPane.children.pop();
     }
     const paneList = createTilePanes(tileElements)[0];
-
-    const testFont = [{ name: 'Pankosmia-Awami Nastaliq for Graphite Test' }];
-    const renderType = useDetectRender({fonts:testFont});
-    const isGraphite = (renderType[0].detectedRender === 'RenderingGraphite')
-    const selectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
+    
+    const isGraphite = GraphiteTest()
+    /** adjSelectedFontClass is reshaped for the presence or absence of Graphite. */
+    const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
     return <>
         <Header
@@ -65,7 +64,7 @@ const Workspace = () => {
             currentId="core-local-workspace"
             widget={<BcvPicker/>}
         />
-        <div className={selectedFontClass}>
+        <div className={adjSelectedFontClass}>
           <TileProvider
               tilePanes={paneList}
               rootNode={rootPane}

--- a/src/pages/Workspace/Workspace.jsx
+++ b/src/pages/Workspace/Workspace.jsx
@@ -54,7 +54,7 @@ const Workspace = () => {
     const paneList = createTilePanes(tileElements)[0];
     
     const isGraphite = GraphiteTest()
-    /** adjSelectedFontClass is reshaped for the presence or absence of Graphite. */
+    /** adjSelectedFontClass reshapes selectedFontClass if Graphite is absent. */
     const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
     return <>

--- a/src/pages/Workspace/Workspace.jsx
+++ b/src/pages/Workspace/Workspace.jsx
@@ -1,16 +1,14 @@
-import React, { useContext } from 'react';
-import {useLocation, useNavigate} from "react-router-dom";
+import { useContext } from 'react';
+import {useLocation} from "react-router-dom";
 import WorkspaceCard from "./WorkspaceCard";
 import BcvPicker from "./BcvPicker";
-import ArrowBack from "@mui/icons-material/ArrowBack";
-import {Box} from "@mui/material";
+import {useDetectRender} from 'font-detect-rhl';
 import {
     createTilePanes,
     TileContainer,
     TileProvider,
 } from 'react-tile-pane'
 import {Header} from "pithekos-lib";
-import {IconButton} from "@mui/material";
 import {typographyContext} from "pithekos-lib";
 
 const paneStyle = {
@@ -55,7 +53,10 @@ const Workspace = () => {
     }
     const paneList = createTilePanes(tileElements)[0];
 
-    const selectedFontClass = typographyRef.current.font_set;
+    const testFont = [{ name: 'Pankosmia-Awami Nastaliq for Graphite Test' }];
+    const renderType = useDetectRender({fonts:testFont});
+    const isGraphite = (renderType[0].detectedRender === 'RenderingGraphite')
+    const selectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
     return <>
         <Header


### PR DESCRIPTION
### This PR is for use in conjunction with or before the planned Electronite version of Liminal.
- Instead detecting the presence of Firefox, this upgrade detects when Graphite rendering exists, whatever the client.

### Important: Please accept "Change to Graphite detection." PRs on the following repos at the same time:
- core-client-settings
- core-client-workspace 
- core-client-content
- core-client-i18n-editor 
- webfonts-core: _Contains new font classes in support of the changes above._
- pankosmia-web: _keeping 1 version of font "truth" until such time as they are no longer included here_
- pithekos: _keeping: 1 version of font "truth" until such time as they are no longer included here_

### Changes to process flow in this repo (run `npm install`):
- GraphiteTest(): Confirm the testFont has loaded, then useDetectRender
- If there is no Graphite then font_set is re-shaped to avoid bonked Awami.
- If Graphite is running then font_set is applied directly.