### PR TITLE
stop truncation of header height equivalent off bottom of page

### DIFF
--- a/src/pages/Workspace/Workspace.jsx
+++ b/src/pages/Workspace/Workspace.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState, useCallback } from 'react';
 import {useLocation} from "react-router-dom";
 import WorkspaceCard from "./WorkspaceCard";
 import BcvPicker from "./BcvPicker";
@@ -57,6 +57,20 @@ const Workspace = () => {
     /** adjSelectedFontClass reshapes selectedFontClass if Graphite is absent. */
     const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 
+    const [maxWindowHeight, setMaxWindowHeight] = useState(window.innerHeight - 48);
+
+    const handleWindowResize = useCallback(() => {
+        setMaxWindowHeight(window.innerHeight - 48);
+    }, []);
+
+
+    useEffect(() => {
+        window.addEventListener('resize', handleWindowResize);
+        return () => {
+            window.removeEventListener('resize', handleWindowResize);
+        };
+    }, [handleWindowResize]);
+
     return <>
         <Header
             titleKey="pages:core-local-workspace:title"
@@ -69,7 +83,7 @@ const Workspace = () => {
               tilePanes={paneList}
               rootNode={rootPane}
           >
-              <div style={{width: '100vw', height: '100vh'}}>
+              <div style={{width: '100vw', height: maxWindowHeight}}>
                   <TileContainer/>
               </div>
           </TileProvider>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2a3b5a37-0093-4c03-9c93-05c372c24aa6)

**NOTE:**  The scrollbars above are representative of an Edit with no resources. Below is an AFTER THIS PR screenshot showing 3 resources panes all scrolled to the bottom, with the inspector confirming there is no more text that exists below that shown in the middle resource onscreen.

![image](https://github.com/user-attachments/assets/e650e3bb-e57f-43b4-a07d-d7d2f8fa308d)
