### PR TITLE
Images muncher slideshow with tailwind css.

### DIFF
--- a/src/munchers/BcvImages/BcvImagesViewerMuncher.jsx
+++ b/src/munchers/BcvImages/BcvImagesViewerMuncher.jsx
@@ -84,7 +84,7 @@ function BcvImagesViewerMuncher({metadata}) {
                 for (const v of verseNotes){
                     let response = await getText(`/burrito/ingredient/raw/${metadata.local_path}?ipath=${v.slice(2)}.txt`, debugRef.current);
                     if (response.ok){
-                        captions = captions.push(response.text);
+                        captions = [...captions, response.text];
                     } else {
                         return "";
                     }
@@ -117,7 +117,7 @@ function BcvImagesViewerMuncher({metadata}) {
                 {ingredient &&
                 verseNotes.length > 0 ? 
                     <div className="relative w-full h-full overflow-hidden">
-                        
+
                         {/* Slider images */}
                         <div
                             className="flex transition-transform duration-300 ease-out h-full"


### PR DESCRIPTION
This PR addresses issue #33 

Added a Slideshow for the Bcv Images muncher:
![chrome_fEosOzE6hZ](https://github.com/user-attachments/assets/f230dbbf-b1a4-407c-95f4-60064741ff36)