### PR TITLE
Obs images won't show as a muncher anymore. 

### DIFF
--- a/src/pages/ConfigureWorkspace/ConfigureWorkspace.jsx
+++ b/src/pages/ConfigureWorkspace/ConfigureWorkspace.jsx
@@ -47,7 +47,7 @@ function ConfigureWorkspace() {
         "x-parallel": "myBcvList",
         "x-bcvImages": "myBcvList",
         "textStories": "myObsList",
-        "x-obsimages": "myObsList",
+        "x-obsimages": [],
         "x-obsarticles": "myObsList",
         "x-obsquestions": "myObsList",
         "x-obsnotes": "myObsList"


### PR DESCRIPTION
This PR addresses issue #79 

Edited the projectFlavors object to prevent the OBS images from showing in the munchers.