### PR TITLE
English Human Readable ISO 639-1

### DIFF
--- a/src/pages/ConfigureWorkspace/ConfigureWorkspace.jsx
+++ b/src/pages/ConfigureWorkspace/ConfigureWorkspace.jsx
@@ -20,6 +20,8 @@ function ConfigureWorkspace() {
 
     const [projectSummaries, setProjectSummaries] = useState({});
 
+    const [languageLookup, setLanguageLookup] = useState([]);
+
     const getProjectSummaries = async () => {
         const summariesResponse = await getJson("/burrito/metadata/summaries", debugRef.current);
         if (summariesResponse.ok) {
@@ -33,6 +35,12 @@ function ConfigureWorkspace() {
         },
         []
     );
+
+    useEffect(() => {
+      fetch('/app-resources/lookups/languages.json') // ISO_639-1 plus grc
+        .then(r => r.json())
+        .then(data => setLanguageLookup(data));
+    }, []);
 
     const projectFlavors = {
         "textTranslation": "myBcvList",
@@ -108,7 +116,8 @@ function ConfigureWorkspace() {
                 name: `${rep.name} (${rep.abbreviation})`,
                 description: rep.description !== rep.name ? rep.description : "",
                 type: rep.flavor,
-                language: rep.language_code
+                language: languageLookup.find(x => x?.id === rep.language_code)?.en ??
+                          rep.language_code
             }
         });
 


### PR DESCRIPTION
This applies the english language name for two-letter ISO 639-1 from the lookup json that we added fairly recently to resource-core. It leave 3-digit codes displayed as 3-digit codes (see arb in the screenshot) and only applies the name to the 2-digit codes (see the other highlighted items in the screenshot.

<img width="940" height="584" alt="image" src="https://github.com/user-attachments/assets/4e394dc0-187f-4e30-9a12-60a38f7fb89d" />
