### PR TITLE
stop collisions by unsetting tw lineHeight

### DIFF
--- a/src/pages/Workspace/WorkspaceCard.jsx
+++ b/src/pages/Workspace/WorkspaceCard.jsx
@@ -154,8 +154,9 @@ function WorkspaceCard({metadata, style, distractionModeCount,locationState}) {
             />
         </div>
     }
+     // Override tailwind with lineHeight: 'normal' to support Awami Nastaliq
      if (metadata.flavor.toLowerCase() === "x-translationplan") {
-        return <div style={style} dir={scriptDirectionString}>
+        return <div style={{...style, lineHeight: 'normal'}} dir={scriptDirectionString}>
             <TranslationPlanViewerMuncher
                 metadata={metadata}
             />


### PR DESCRIPTION
This PR adds ` lineHeight: 'normal'`, overriding tailwind line-height causing row collisions in Awami Nastaliq.

(Direction will be addressed in a separate PR)

| Before | After |
|---|---|
| <img width="806" height="242" alt="collisions caused by tw lineHeight" src="https://github.com/user-attachments/assets/de767319-6c9b-4dd1-b8bf-de56d7b14165" /> | <img width="899" height="401" alt="collision stopped by normal lineHeight" src="https://github.com/user-attachments/assets/60f55b64-a465-4cf7-87fe-ac9193feb461" /> |
