### PR TITLE
Handle nonexistent script_direction key

### DIFF
--- a/src/munchers/BNotes/BNotesViewerMuncher.jsx
+++ b/src/munchers/BNotes/BNotesViewerMuncher.jsx
@@ -14,13 +14,15 @@ import TextDir from '../helpers/TextDir';
 
 function BNotesViewerMuncher({metadata}) {
     const [ingredient, setIngredient] = useState("");
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
     
     const {systemBcv} = useContext(BcvContext);
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     const getAllData = async () => {

--- a/src/munchers/BcvArticles/BcvArticlesViewerMuncher.jsx
+++ b/src/munchers/BcvArticles/BcvArticlesViewerMuncher.jsx
@@ -16,13 +16,15 @@ import TextDir from '../helpers/TextDir';
 function BcvArticlesViewerMuncher({metadata}) {
     const [ingredient, setIngredient] = useState([]);
     const [verseNotes, setVerseNotes] = useState([]);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
     const {systemBcv} = useContext(BcvContext);
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     const getAllData = async () => {

--- a/src/munchers/BcvImages/BcvImagesViewerMuncher.jsx
+++ b/src/munchers/BcvImages/BcvImagesViewerMuncher.jsx
@@ -24,13 +24,15 @@ function ImageViewer({metadata, reference}) {
 function BcvImagesViewerMuncher({metadata}) {
     const [ingredient, setIngredient] = useState([]);
     const [verseNotes, setVerseNotes] = useState([]);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
     const {systemBcv} = useContext(BcvContext);
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
     
     let [current, setCurrent] = useState(0);

--- a/src/munchers/BcvNotes/BcvNotesViewerMuncher.jsx
+++ b/src/munchers/BcvNotes/BcvNotesViewerMuncher.jsx
@@ -14,13 +14,15 @@ import TextDir from '../helpers/TextDir';
 
 function BcvNotesViewerMuncher({ metadata }) {
     const [ingredient, setIngredient] = useState([]);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
     const { systemBcv } = useContext(BcvContext);
     const { debugRef } = useContext(DebugContext);
     const { i18nRef } = useContext(I18nContext);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     const getAllData = async () => {

--- a/src/munchers/BcvQuestions/BcvQuestionsViewerMuncher.jsx
+++ b/src/munchers/BcvQuestions/BcvQuestionsViewerMuncher.jsx
@@ -15,13 +15,15 @@ import TextDir from '../helpers/TextDir';
 
 function BcvQuestionsViewerMuncher({metadata}) {
     const [ingredient, setIngredient] = useState([]);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
     const {systemBcv} = useContext(BcvContext);
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     const getAllData = async () => {

--- a/src/munchers/BcvVideos/BcvVideosViewerMuncher.jsx
+++ b/src/munchers/BcvVideos/BcvVideosViewerMuncher.jsx
@@ -24,13 +24,15 @@ function VideoViewer({metadata, reference}) {
 function BcvImagesViewerMuncher({metadata}) {
     const [ingredient, setIngredient] = useState([]);
     const [verseNotes, setVerseNotes] = useState([]);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
     const {systemBcv} = useContext(BcvContext);
     const {debugRef} = useContext(DebugContext);
     const {i18nRef} = useContext(I18nContext);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
     
     let [current, setCurrent] = useState(0);

--- a/src/munchers/TextTranslation/SimplifiedEditor/DraftingEditor.jsx
+++ b/src/munchers/TextTranslation/SimplifiedEditor/DraftingEditor.jsx
@@ -27,9 +27,11 @@ function DraftingEditor(
     const [md5sumScriptureJson, setMd5sumScriptureJson] = useState([]);
     const [currentBookCode, setCurrentBookCode] = useState("zzz");
     const [bookChangeCount, setBookChangeCount] = useState(0);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     // Set up 'are you sure you want to leave page' for Electron

--- a/src/munchers/TextTranslation/SimplifiedEditor/components/ChapterPicker.jsx
+++ b/src/munchers/TextTranslation/SimplifiedEditor/components/ChapterPicker.jsx
@@ -14,7 +14,7 @@ function ChapterPicker({ repoMetadata, chapterNumbers }) {
         const summariesResponse = await getJson(`/burrito/metadata/summary/${repoMetadata.local_path}`);
         if (summariesResponse.ok) {
             const data = summariesResponse.json;
-            setScriptDirection(data.script_direction);
+            setScriptDirection(data?.script_direction ?? undefined);
         } else {
             console.error(" Erreur lors de la récupération des données.");
         }

--- a/src/munchers/TextTranslation/TextTranslationViewerMuncher.jsx
+++ b/src/munchers/TextTranslation/TextTranslationViewerMuncher.jsx
@@ -11,9 +11,11 @@ function TextTranslationViewerMuncher({metadata}) {
     const {systemBcv} = useContext(bcvContext);
     const {debugRef} = useContext(debugContext);
     const [verseText, setVerseText] = useState([]);
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     useEffect(

--- a/src/munchers/TranslationPlan/TranslationPlanViewerMuncher.jsx
+++ b/src/munchers/TranslationPlan/TranslationPlanViewerMuncher.jsx
@@ -33,11 +33,13 @@ function TranslationPlanViewerMuncher({metadata}) {
     const [selectedBurrito, setSelectedBurrito] = useState(null);
     const [selectedStory, setSelectedStory] = useState();
     const [search, setSearch] = useState("");
-    const [textDir, setTextDir] = useState(metadata.script_direction.toLowerCase());
+    const [textDir, setTextDir] = useState(
+      metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
+    );
     const [selectedBurritoSbTextDir, setSelectedBurritoSbTextDir] = useState(undefined);
     const [selectedBurritoTextDir, setSelectedBurritoTextDir] = useState(undefined);
 
-    const sbScriptDir = metadata.script_direction.toLowerCase();
+    const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
     const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     const [anchorEl, setAnchorEl] = useState(null);
@@ -157,8 +159,12 @@ function TranslationPlanViewerMuncher({metadata}) {
 
     useEffect(() => {
         if (selectedBurrito !== null) {
-            setSelectedBurritoSbTextDir(selectedBurrito.script_direction.toLowerCase());
-            setSelectedBurritoTextDir(selectedBurrito.script_direction.toLowerCase());
+            setSelectedBurritoSbTextDir(
+              selectedBurrito?.script_direction ? selectedBurrito.script_direction.toLowerCase() : undefined
+            );
+            setSelectedBurritoTextDir(
+              selectedBurrito?.script_direction ? selectedBurrito.script_direction.toLowerCase() : undefined
+            );
         }
     },[selectedBurrito])
 

--- a/src/pages/Workspace/WorkspaceCard.jsx
+++ b/src/pages/Workspace/WorkspaceCard.jsx
@@ -22,7 +22,7 @@ import TranslationPlanViewerMuncher from '../../munchers/TranslationPlan/Transla
 
 function WorkspaceCard({metadata, style, distractionModeCount,locationState}) {
 
-  const sbScriptDir = metadata.script_direction.toLowerCase();
+  const sbScriptDir = metadata?.script_direction ? metadata.script_direction.toLowerCase() : undefined
   const sbScriptDirSet = sbScriptDir === 'ltr' || sbScriptDir === 'rtl';
 
     if (!metadata.primary && (distractionModeCount % 2) > 0) {


### PR DESCRIPTION
This PR handles the case where an SB does not contain the field `script_direction`.

Also, per spec the type is string. The approach used is going by this spec and is _**not**_ double checking first to make sure it really a string before toLowerCase().

<img width="436" height="76" alt="image" src="https://github.com/user-attachments/assets/3a540cb5-cf63-4edc-935e-88557cff92cb" />

<sup>https://docs.burrito.bible/en/latest/schema_docs/language.html</sup>