### PR TITLE
Audio editor RC3

### DIFF
--- a/src/munchers/OBS/components/AudioRecorder.jsx
+++ b/src/munchers/OBS/components/AudioRecorder.jsx
@@ -557,11 +557,14 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
   // Raccourci clavier
   useEffect(() => {
     const onKey = (e) => {
+      // Quand le focus est dans un champ de saisie ou dans l'éditeur de texte
+      const target = e.target;
+      const tag = target?.tagName;
+      const isTyping =
+        tag === "INPUT" || tag === "TEXTAREA" || !!target?.isContentEditable;
+      if (isTyping) return;
+
       const isCmd = e.ctrlKey || e.metaKey;
-      // Ignore les touches "nues" (espace, s, r, Delete…) quand on tape dans
-      // un input (rename, etc.) : sinon preventDefault avale le caractère.
-      const tag = e.target?.tagName;
-      const isTyping = tag === "INPUT" || tag === "TEXTAREA";
 
       // Undo shortcut
       if (isCmd && e.key.toLowerCase() === "z" && !e.shiftKey) {
@@ -593,7 +596,6 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
       }
       // Suppr/Backspace : selon le contexte
       else if (e.key === "Delete" || e.key === "Backspace") {
-        if (isTyping) return;
         if (clipSelection.length > 0) {
           e.preventDefault();
           deleteSelectedClips();
@@ -608,14 +610,12 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
       }
       // Espace : Play / Pause
       else if (e.key === " ") {
-        if (isTyping) return;
         e.preventDefault();
         if (isPlaying) stop();
         else play();
       }
       // S : Split sur le Playherd
       else if (e.key === "s") {
-        if (isTyping) return;
         e.preventDefault();
         splitAtPlayhead();
       } else if (isCmd && e.key === "a") {
@@ -639,7 +639,6 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
       }
       // R : Record
       else if (e.key.toLowerCase() === "r" && !isCmd) {
-        if (isTyping) return;
         e.preventDefault();
         if (isRecording) stopRecording();
         else record();

--- a/src/munchers/OBS/components/AudioRecorder.jsx
+++ b/src/munchers/OBS/components/AudioRecorder.jsx
@@ -921,33 +921,42 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
             {formatTime(displayTime, true)}
           </Box>
 
-          <IconButton
-            size="small"
-            onClick={cursorToStart}
-            disabled={tracks.length === 0}
-            title="Cursor to start"
-          >
-            <CursorToStartIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={isPlaying ? stop : play}
-            disabled={tracks.length === 0}
-            title={isPlaying ? "Stop (space)" : "Play (space)"}
-          >
-            {isPlaying ? <StopIcon /> : <PlayArrowIcon />}
-          </IconButton>
+          <Tooltip title="Cursor to start">
+            <span>
+              <IconButton
+                size="small"
+                onClick={cursorToStart}
+                disabled={tracks.length === 0}
+              >
+                <CursorToStartIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title={isPlaying ? "Stop (space)" : "Play (space)"}>
+            <span>
+              <IconButton
+                size="small"
+                onClick={isPlaying ? stop : play}
+                disabled={tracks.length === 0}
+              >
+                {isPlaying ? <StopIcon /> : <PlayArrowIcon />}
+              </IconButton>
+            </span>
+          </Tooltip>
           <Box sx={{ display: "flex", alignItems: "center" }}>
-            <IconButton
-              size="small"
-              onClick={isRecording ? stopRecording : record}
-              color={isRecording ? "error" : "default"}
-              disabled={!paths}
-              title={isRecording ? "Stop recording (R)" : "Record (R)"}
-              sx={{ pr: 0.25 }}
-            >
-              {isRecording ? <StopIcon /> : <MicIcon />}
-            </IconButton>
+            <Tooltip title={isRecording ? "Stop recording (R)" : "Record (R)"}>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={isRecording ? stopRecording : record}
+                  color={isRecording ? "error" : "default"}
+                  disabled={!paths}
+                  sx={{ pr: 0.25 }}
+                >
+                  {isRecording ? <StopIcon /> : <MicIcon />}
+                </IconButton>
+              </span>
+            </Tooltip>
             <MicSourcePicker
               source={audioSource}
               onChange={changeAudioSource}
@@ -955,54 +964,72 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
               disabled={isRecording}
             />
           </Box>
-          <IconButton
-            size="small"
-            onClick={copySelection}
-            disabled={!regionSelection && clipSelection.length === 0}
-            title={`Copy (${ctrlKeyTitle} + C)`}
-          >
-            <ContentCopyIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={pasteAtCursor}
-            disabled={!clipboard || !selection}
-            title="Paste (Ctrl + V)"
-          >
-            <ContentPasteIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={cutSelection}
-            disabled={!regionSelection && clipSelection.length === 0}
-            title="Cut (Ctrl + X)"
-          >
-            <ContentCutIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={splitAtPlayhead}
-            disabled={!selection && !isPlaying}
-            title="Split at cursor (S)"
-          >
-            <SplitIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={undo}
-            disabled={past.length === 0}
-            title="Undo (Ctrl + Z)"
-          >
-            <UndoIcon fontSize="small" />
-          </IconButton>
-          <IconButton
-            size="small"
-            onClick={redo}
-            disabled={future.length === 0}
-            title="Redo (Ctrl + Y)"
-          >
-            <RedoIcon fontSize="small" />
-          </IconButton>
+          <Tooltip title={`Copy (${ctrlKeyTitle} + C)`}>
+            <span>
+              <IconButton
+                size="small"
+                onClick={copySelection}
+                disabled={!regionSelection && clipSelection.length === 0}
+              >
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Paste (Ctrl + V)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={pasteAtCursor}
+                disabled={!clipboard || !selection}
+              >
+                <ContentPasteIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Cut (Ctrl + X)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={cutSelection}
+                disabled={!regionSelection && clipSelection.length === 0}
+              >
+                <ContentCutIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Split at cursor (S)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={splitAtPlayhead}
+                disabled={!selection && !isPlaying}
+              >
+                <SplitIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Undo (Ctrl + Z)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={undo}
+                disabled={past.length === 0}
+              >
+                <UndoIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Redo (Ctrl + Y)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={redo}
+                disabled={future.length === 0}
+              >
+                <RedoIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
           <Tooltip
             title={
               <Box sx={{ whiteSpace: "pre-line" }}>

--- a/src/munchers/OBS/components/AudioRecorder.jsx
+++ b/src/munchers/OBS/components/AudioRecorder.jsx
@@ -11,8 +11,10 @@ import ContentCutIcon from "@mui/icons-material/ContentCutOutlined";
 import UndoIcon from "@mui/icons-material/UndoOutlined";
 import RedoIcon from "@mui/icons-material/RedoOutlined";
 import AddIcon from "@mui/icons-material/AddOutlined";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
+import Tooltip from "@mui/material/Tooltip";
 
 import TrackView from "./TrackView";
 import { scheduleTrackFrom, stopSources } from "./lib/playback";
@@ -1001,17 +1003,19 @@ export default function AudioRecorder({ audioUrl, obs, metadata, book }) {
           >
             <RedoIcon fontSize="small" />
           </IconButton>
+          <Tooltip
+            title={
+              <Box sx={{ whiteSpace: "pre-line" }}>
+                {`${ctrlKeyTitle} + Click to multiple select
+                ← and → to move selection`}
+              </Box>
+            }
+          >
+            <IconButton size="small" disableRipple sx={{ cursor: "default" }}>
+              <HelpOutlineIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </Stack>
-        <Box
-          sx={{
-            marginLeft: "auto",
-            paddingRight: 4,
-            color: "#666",
-            fontSize: 14,
-          }}
-        >
-          Ctrl to multiple select, ← and → to move selection
-        </Box>
       </Stack>
 
       <Box sx={{ border: "2px solid #777", borderTop: "0px solid #777" }}>

--- a/src/munchers/OBS/components/MicSourcePicker.jsx
+++ b/src/munchers/OBS/components/MicSourcePicker.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import ListItemIcon from "@mui/material/ListItemIcon";
@@ -137,15 +138,18 @@ export default function MicSourcePicker({
 
   return (
     <>
-      <IconButton
-        size="small"
-        onClick={(e) => setAnchorEl(e.currentTarget)}
-        disabled={disabled}
-        title="Audio input source"
-        sx={{ p: 0, ml: -0.5 }}
-      >
-        <ExpandMoreIcon sx={{ fontSize: 16 }} />
-      </IconButton>
+      <Tooltip title="Audio input source">
+        <span>
+          <IconButton
+            size="small"
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            disabled={disabled}
+            sx={{ p: 0, ml: -0.5 }}
+          >
+            <ExpandMoreIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+        </span>
+      </Tooltip>
       <Menu
         anchorEl={anchorEl}
         open={open}


### PR DESCRIPTION
## Overview
This PR fixes several bugs and adds new features described in https://github.com/pankosmia/roadmap/issues/147

## Bugs fixed
### Some keys doesn't work in text editor
>  Keys with audio shortcuts doesn't work in the text editor box above. Do we want to add Ctrl to all shortcuts or do we solve this another way?

Add verification to prevent audio shortcut in text edit. `tag === "INPUT" || tag === "TEXTAREA" `

### Buttons use the wrong tooltip.

Replaced native tooltips by mui tooltips
| Before PR | After PR |
| --- | --- |
| <img width="144" height="96" alt="image" src="https://github.com/user-attachments/assets/229ad5f1-c722-4cce-b1ac-a015ae4d1d4e" /> | <img width="134" height="92" alt="image" src="https://github.com/user-attachments/assets/2d02ca6c-b015-4c7f-b324-5da4a3081519" /> |

## Features added
### Icon for shortcut
>  Move the shortcut messages in a ? tooltip (icon button but without click effect, shows tooltip on hover). One tip per line.
We may have the ? icon button without click as a RCL component? If not, would be nice to do it.

Added an icon with tooltips, and removed old tooltip text.

| Before PR | After PR |
| --- | --- |
| <img width="300" height="150" alt="image" src="https://github.com/user-attachments/assets/05867c75-0179-4bf0-ba5b-733e821d61d0" /> | <img width="173" height="148" alt="image" src="https://github.com/user-attachments/assets/1bda0b87-6e39-4f68-b35c-cdd74494c1d8" /> |


### Zoom in timeline
>  Need a zoom. Let's talk about ways to do that before jumping in.
